### PR TITLE
feat(header): prevent body scroll when mobile menu is open

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { NAV_LINKS } from "./data";
 
 const Header = () => {
@@ -8,6 +8,14 @@ const Header = () => {
   if (!NAV_LINKS || NAV_LINKS.length === 0) {
     return null;
   }
+  useEffect(() => {
+    if (isOpen) {
+      document.body.classList.add("overflow-hidden");
+    } else {
+      document.body.classList.remove("overflow-hidden");
+    }
+    return () => document.body.classList.remove("overflow-hidden");
+  }, [isOpen]);
   return (
     <header className="relative flex h-[84px] items-center justify-between">
       <img src="./icon.png" className="hidden h-6 w-6 sm:block" alt="Logo" />

--- a/src/components/sections/ProductSpotlight/ProductSpotlight.tsx
+++ b/src/components/sections/ProductSpotlight/ProductSpotlight.tsx
@@ -66,7 +66,7 @@ const ProductSpotlight = () => {
               <button
                 onClick={() => handleShoes(el)}
                 key={el.id}
-                className={`relative h-[88px] w-[88px] flex-shrink-0 overflow-hidden rounded-[8px] ${
+                className={`last:mr-0 relative mr-[16px] h-[88px] w-[88px] flex-shrink-0 overflow-hidden rounded-[8px] ${
                   isActive
                     ? "rounded-[8px] border border-[2px] border-[#111111]"
                     : ""

--- a/src/components/sections/ProductSpotlight/data.ts
+++ b/src/components/sections/ProductSpotlight/data.ts
@@ -24,10 +24,6 @@ export const PRODUCT_DATA: ProductType[] = [
     src: "/images/productSpotlight/black_air.png",
     thumbnails: [
       "/images/productSpotlight/black_air.png",
-      "/images/productSpotlight/black_air.png",
-      "/images/productSpotlight/black_air.png",
-      "/images/productSpotlight/black_air.png",
-      "/images/productSpotlight/black_air.png",
     ],
     size: [38, 39, 40, 41, 42, 43],
   },
@@ -38,10 +34,6 @@ export const PRODUCT_DATA: ProductType[] = [
     price: 280,
     src: "/images/productSpotlight/white_air.png",
     thumbnails: [
-      "/images/productSpotlight/white_air.png",
-      "/images/productSpotlight/white_air.png",
-      "/images/productSpotlight/white_air.png",
-      "/images/productSpotlight/white_air.png",
       "/images/productSpotlight/white_air.png",
     ],
     size: [38, 39, 40, 41, 42, 43],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents page scrolling when mobile menu is active

* **Style**
  * Enhanced spacing between product variant selection buttons

* **Chores**
  * Cleaned up redundant product data entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->